### PR TITLE
パワポ画面表示なしの動作+1

### DIFF
--- a/pptshape/ppt.py
+++ b/pptshape/ppt.py
@@ -19,9 +19,9 @@ class PPTShape:
         # [12, 0] for PP2007
         self.old = self.appver <= [12, 0]
         self.filename = filename
-        if self.old:
-            self.ppt.Visible = 1 # need to open with PP2007
-        self.presentation = self.ppt.Presentations.Open(self.filename)
+        self.presentation = self.ppt.Presentations.Open(self.filename,
+                                                        WithWindow=0)
+
     def __del__(self):
         self.quit()
 

--- a/pptshape/ppt.py
+++ b/pptshape/ppt.py
@@ -13,6 +13,7 @@ class PPTShape:
     VER_PP2007 = '12.0'
 
     def __init__(self, filename):
+        self.ppt = None
         self.ppt = win32com.client.gencache.EnsureDispatch("PowerPoint.Application") 
         self.appver = map(int, self.ppt.Version.split('.'))
         # [12, 0] for PP2007
@@ -21,9 +22,12 @@ class PPTShape:
         if self.old:
             self.ppt.Visible = 1 # need to open with PP2007
         self.presentation = self.ppt.Presentations.Open(self.filename)
+    def __del__(self):
+        self.quit()
 
     def quit(self):
-        self.ppt.Quit()
+        if self.ppt:
+            self.ppt.Quit()
         self.ppt = None
 
     def shapes(self):

--- a/test/testdoc/index.rst
+++ b/test/testdoc/index.rst
@@ -11,6 +11,8 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+.. For this image, use "#1" or "#1.1" for shapename with PowerPoint 2007 
+
 .. ppt-shape:: abc.png
    :pptfilename: testppt.pptx
    :shapename: shape-title


### PR DESCRIPTION
画像出力中にパワポ画面が出ないような開き方にしたのと、
エラー発生時にパワポのインスタンスがの頃らないように必ずQuit()
するようにしてみました。
